### PR TITLE
fix(noaa): read wind units from the API unitCode (#817)

### DIFF
--- a/src/wxdat/providers/noaa.py
+++ b/src/wxdat/providers/noaa.py
@@ -4,11 +4,19 @@ https://www.weather.gov/documentation/services-web-api
 """
 
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel
-from wamu import Celsius, Meter, MetersPerSecond, MillimetersPerHour, Pascal
+from wamu import (
+    Celsius,
+    KilometersPerHour,
+    Meter,
+    MetersPerSecond,
+    MillimetersPerHour,
+    Pascal,
+)
 
 from ..database import CurrentConditions
 from . import BaseStation, WeatherObservation, WeatherProvider
@@ -27,6 +35,52 @@ class API_Measurement(BaseModel):
     unitCode: str
     qualityControl: str
     value: float | None = None
+
+
+# Conversions from the units the API may report to the units we store, keyed by the
+# `unitCode` carried on each measurement.  The API declares its units per-field, so we
+# convert from what it says rather than assuming.
+FAHRENHEIT = {
+    "wmoUnit:degC": lambda value: Celsius(value).fahrenheit,
+}
+
+MILES_PER_HOUR = {
+    "wmoUnit:km_h-1": lambda value: KilometersPerHour(value).miles_per_hr,
+    "wmoUnit:m_s-1": lambda value: MetersPerSecond(value).miles_per_hr,
+}
+
+INCHES_MERCURY = {
+    "wmoUnit:Pa": lambda value: Pascal(value).inches_mercury,
+}
+
+MILES = {
+    "wmoUnit:m": lambda value: Meter(value).miles,
+}
+
+# the API reports accumulation over the preceding hour, which we store as a rate
+INCHES_PER_HOUR = {
+    "wmoUnit:mm": lambda value: MillimetersPerHour(value).inches_per_hour,
+}
+
+
+def convert(
+    measurement: API_Measurement | None,
+    units: dict[str, Callable[[float], float]],
+) -> float | None:
+    """Convert a measurement to our storage units, using the unit the API declared."""
+
+    if measurement is None or measurement.value is None:
+        return None
+
+    convert_from = units.get(measurement.unitCode)
+
+    # an unrecognized unit means the API is reporting something we have not been told
+    # how to read -- drop the field rather than record a value scaled by the wrong factor
+    if convert_from is None:
+        logger.warning("unsupported unitCode '%s'; dropping value", measurement.unitCode)
+        return None
+
+    return convert_from(measurement.value)
 
 
 class API_Properties(BaseModel):
@@ -56,21 +110,23 @@ class API_Properties(BaseModel):
     rawMessage: str | None = None
 
     @property
-    def feelsLike(self):
-        if self.temperature is None or self.temperature.value is None:
+    def feelsLike(self) -> API_Measurement | None:
+        """Return the measurement that best represents the apparent temperature."""
+
+        temp = convert(self.temperature, FAHRENHEIT)
+
+        if temp is None:
             return None
 
-        temp = Celsius(self.temperature.value)
-
         # use heat index if temp is over 70 F
-        if temp.fahrenheit >= 70:
-            return self.heatIndex.value
+        if temp >= 70:
+            return self.heatIndex
 
         # use wind chill if temp is below 61 F
-        if temp.fahrenheit <= 61:
-            return self.windChill.value
+        if temp <= 61:
+            return self.windChill
 
-        return self.temperature.value
+        return self.temperature
 
 
 class API_Observation(BaseModel):
@@ -102,32 +158,21 @@ class Station(BaseStation):
 
         props = weather.properties
 
-        # set up fields for conversion
-        temperature = Celsius(props.temperature.value)
-        feels_like = Celsius(props.feelsLike)
-        dew_point = Celsius(props.dewpoint.value)
-        wind_speed = MetersPerSecond(props.windSpeed.value)
-        wind_gusts = MetersPerSecond(props.windGust.value)
-        precip_hour = MillimetersPerHour(props.precipitationLastHour.value)
-        abs_pressure = Pascal(props.barometricPressure.value)
-        rel_pressure = Pascal(props.seaLevelPressure.value)
-        visibility = Meter(props.visibility.value)
-
         return CurrentConditions(
             timestamp=props.timestamp,
             provider=self.provider,
             station_id=self.station,
-            temperature=temperature.fahrenheit,
-            feels_like=feels_like.fahrenheit,
-            dew_point=dew_point.fahrenheit,
-            wind_speed=wind_speed.miles_per_hr,
-            wind_gusts=wind_gusts.miles_per_hr,
+            temperature=convert(props.temperature, FAHRENHEIT),
+            feels_like=convert(props.feelsLike, FAHRENHEIT),
+            dew_point=convert(props.dewpoint, FAHRENHEIT),
+            wind_speed=convert(props.windSpeed, MILES_PER_HOUR),
+            wind_gusts=convert(props.windGust, MILES_PER_HOUR),
             wind_bearing=props.windDirection.value,
             humidity=props.relativeHumidity.value,
-            precip_hour=precip_hour.inches_per_hour,
-            abs_pressure=abs_pressure.inches_mercury,
-            rel_pressure=rel_pressure.inches_mercury,
-            visibility=visibility.miles,
+            precip_hour=convert(props.precipitationLastHour, INCHES_PER_HOUR),
+            abs_pressure=convert(props.barometricPressure, INCHES_MERCURY),
+            rel_pressure=convert(props.seaLevelPressure, INCHES_MERCURY),
+            visibility=convert(props.visibility, MILES),
             remarks=props.rawMessage,
         )
 

--- a/tests/test_noaa.py
+++ b/tests/test_noaa.py
@@ -1,8 +1,43 @@
 """Unit tests for the NOAA provider."""
 
+import logging
+
 import pytest
 
 from wxdat.providers import noaa
+
+# Expected observation values per station, verified against the raw METAR recorded in
+# each cassette.  The NWS API reports wind in km/h; the METAR reports it in knots.
+EXPECTED = {
+    # KDEN 081653Z 22013KT 10SM CLR M04/M12 A3023 -- 13 kt sustained, no gust
+    "KDEN": {
+        "temperature": 24.08,
+        "feels_like": 11.45,
+        "dew_point": 10.94,
+        "wind_speed": 14.9875,
+        "wind_gusts": None,
+        "wind_bearing": 220,
+        "humidity": 56.7556,
+        "precip_hour": None,
+        "abs_pressure": None,
+        "rel_pressure": 30.3686,
+        "visibility": 9.9979,
+    },
+    # KSEA 081653Z 00000KT 10SM BKN022 06/04 A3050 -- calm
+    "KSEA": {
+        "temperature": 42.98,
+        "feels_like": None,
+        "dew_point": 39.92,
+        "wind_speed": 0.0,
+        "wind_gusts": None,
+        "wind_bearing": 0,
+        "humidity": 88.8585,
+        "precip_hour": None,
+        "abs_pressure": 30.5015,
+        "rel_pressure": 30.5251,
+        "visibility": 9.9979,
+    },
+}
 
 
 @pytest.fixture(scope="function", params=["KDEN", "KSEA"])
@@ -29,3 +64,87 @@ def test_noaa_conditions(station: noaa.Station):
 
     assert conditions is not None
     assert conditions.timestamp is not None
+
+    for field, value in EXPECTED[station.station].items():
+        observed = getattr(conditions, field)
+
+        if value is None:
+            assert observed is None, field
+        else:
+            assert observed == pytest.approx(value, abs=0.0001), field
+
+
+def measurement(unit_code, value):
+    """Return an API measurement reported in the given unit."""
+
+    return noaa.API_Measurement(unitCode=unit_code, qualityControl="V", value=value)
+
+
+def test_convert_speed_from_kilometers_per_hour():
+    """Verify a speed reported in km/h converts to mph."""
+
+    assert noaa.convert(measurement("wmoUnit:km_h-1", 24.12), noaa.MILES_PER_HOUR) == pytest.approx(
+        14.99, abs=0.01
+    )
+
+
+def test_convert_speed_from_meters_per_second():
+    """Verify a speed reported in m/s converts to mph."""
+
+    assert noaa.convert(measurement("wmoUnit:m_s-1", 24.12), noaa.MILES_PER_HOUR) == pytest.approx(
+        53.95, abs=0.01
+    )
+
+
+def test_convert_unrecognized_unit_is_dropped(caplog):
+    """Verify an unexpected unit is dropped with a warning instead of being assumed."""
+
+    with caplog.at_level(logging.WARNING):
+        value = noaa.convert(measurement("wmoUnit:kt", 13.0), noaa.MILES_PER_HOUR)
+
+    assert value is None
+    assert "wmoUnit:kt" in caplog.text
+
+
+def test_convert_absent_measurement_is_none():
+    """Verify a measurement missing from the response converts to nothing."""
+
+    assert noaa.convert(None, noaa.MILES_PER_HOUR) is None
+
+
+def test_convert_empty_measurement_is_none():
+    """Verify a measurement reported without a value converts to nothing."""
+
+    assert noaa.convert(measurement("wmoUnit:km_h-1", None), noaa.MILES_PER_HOUR) is None
+
+
+def test_convert_temperature_from_celsius():
+    """Verify a temperature reported in degrees C converts to degrees F."""
+
+    assert noaa.convert(measurement("wmoUnit:degC", 100.0), noaa.FAHRENHEIT) == pytest.approx(
+        212.0, abs=0.0001
+    )
+
+
+def test_convert_pressure_from_pascals():
+    """Verify a pressure reported in pascals converts to inches of mercury."""
+
+    assert noaa.convert(measurement("wmoUnit:Pa", 101325.0), noaa.INCHES_MERCURY) == pytest.approx(
+        29.9213, abs=0.0001
+    )
+
+
+def test_convert_distance_from_meters():
+    """Verify a distance reported in meters converts to miles."""
+
+    assert noaa.convert(measurement("wmoUnit:m", 1609.344), noaa.MILES) == pytest.approx(
+        1.0, abs=0.0001
+    )
+
+
+def test_convert_precipitation_from_millimeters():
+    """Verify hourly precipitation reported in mm converts to inches per hour."""
+
+    assert noaa.convert(measurement("wmoUnit:mm", 25.4), noaa.INCHES_PER_HOUR) == pytest.approx(
+        1.0, abs=0.0001
+    )


### PR DESCRIPTION
Fixes #817.

## Problem

The NWS API reports wind in km/h, but `noaa.py` wrapped the value in `MetersPerSecond` before converting to mph. Since m/s → km/h is exactly 3.6, every NOAA `wind_speed` and `wind_gusts` reading was inflated by that factor.

`API_Measurement.unitCode` already parsed the unit the API declares on every field — it was simply never read.

## Approach

Dispatch on `unitCode` rather than assuming. Each measured field maps its reported code to the right conversion through a shared `convert()` helper, so this covers temperature, pressure, visibility and precipitation against future drift as well as wind.

An unrecognized code logs a warning and drops that single field rather than raising — this is a long-lived collection service, and killing the whole observation would trade silently-wrong wind for silently-missing everything.

`feelsLike` now returns the measurement instead of a bare float so it dispatches like every other field, which also removes a latent `AttributeError` when `heatIndex`/`windChill` is absent from a response.

## Verification

Validated against the raw METAR recorded in each cassette — an independent unit in the same row, so the check isn't circular:

| station | API | METAR | before | after |
|---|---|---|---|---|
| KDEN | 24.12 km/h | `22013KT` (13 kt = 14.96 mph) | 53.95 mph | **14.99 mph** |
| KSEA | 0 km/h | `00000KT` (calm) | 0.0 mph | 0.0 mph |

Tests went 3 → 12 on this module. The regression test that reproduces the bug is a value assertion on the existing KDEN cassette; no new fixtures were needed. Full-field assertions on both cassettes confirm temperature, pressure, visibility and precipitation values are unchanged by the refactor.

`uv run pytest` → 18 passed, 4 skipped (the same API-key-gated skips as a clean `main`). Ruff and pyright clean.

## Not included

- **Historical data.** This corrects readings going forward; NOAA wind values already stored remain inflated by 3.6x. The correction is deterministic (`/ 3.6` where `provider = 'NOAA'`) but is deliberately left out of this PR.
- **`wind_bearing` and `humidity`** still read `.value` directly. They're unitless (`degree_(angle)`, `percent`) and so sit outside the unit-dispatch problem, but they are now the only two fields that would raise if the API omitted the key. Pre-existing, and hardening it is new behavior wanting its own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
